### PR TITLE
Setup resConfig to FR and AR

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,7 @@ android {
         buildConfigField "String", "V2_CHARACTERISTIC_ID", V2_CHARACTERISTIC_ID
         buildConfigField "int", "ERROR_NOTIFICATION_ID", ERROR_NOTIFICATION_ID
 
+        resConfigs "fr", "ar"
     }
 
     buildTypes {


### PR DESCRIPTION
Libraries include language resources (such as AppCompat or Google Play Services), then your APK includes all translated language strings for the messages in those libraries whether the rest of your app is translated to the same languages or not. If you'd like to keep only the languages that your app officially supports, you can specify those languages using the resConfig property. Any resources for languages not specified are removed.